### PR TITLE
Remove duplicate test from Rust Atomics and Locks

### DIFF
--- a/memlog/tests/atomics_and_locks.rs
+++ b/memlog/tests/atomics_and_locks.rs
@@ -452,42 +452,6 @@ fn test_3_10() {
 }
 
 // Listing 3.11
-// Tests sequential consistent flags protecting data access
-#[test]
-fn test_3_11() {
-    fn inner() -> Vec<usize> {
-        let mut lt = LogTest::default();
-
-        lt.add(|mut eg: Environment| {
-            eg.b.store(1, Ordering::SeqCst);
-            if eg.a.load(Ordering::SeqCst) == 0 {
-                // Todo: Use nonatomic stores here for eg.c
-                eg.c.fetch_op(|v| v + 1, Ordering::Relaxed);
-            }
-
-            eg.c.load(Ordering::Relaxed)
-        });
-
-        lt.add(|mut eg: Environment| {
-            eg.a.store(1, Ordering::SeqCst);
-            if eg.b.load(Ordering::SeqCst) == 0 {
-                eg.c.fetch_op(|v| v + 1, Ordering::Relaxed);
-            }
-
-            eg.c.load(Ordering::Relaxed)
-        });
-
-        lt.run()
-    }
-
-    // At most one store is made to C, and either thread may see it if it occurs
-    assert!(run_until(
-        inner,
-        vec![vec![0, 1], vec![1, 0], vec![0, 0], vec![1, 1]]
-    ));
-}
-
-// Listing 3.12
 // Tests Atomic-Fence synchronisation, where an atomic Release operation on the writer thread synchronises with
 // an Acquire fence on the reader thread
 #[test]

--- a/memlog/tests/common/harness.rs
+++ b/memlog/tests/common/harness.rs
@@ -10,7 +10,6 @@ pub struct ThreadState {
     pub finished: bool,
     pub waiting: bool,
     pub barrier: Arc<Barrier>,
-    pub position: usize,
 }
 
 impl ThreadState {
@@ -100,6 +99,7 @@ impl Value {
     }
 }
 
+#[allow(unused)]
 pub struct Environment {
     pub thread_state: Arc<Mutex<ThreadState>>,
     pub a: Value,
@@ -144,7 +144,6 @@ impl<T: Copy + Send + 'static> LogTest<T> {
             finished: false,
             waiting: false,
             barrier: Arc::new(Barrier::new(2)),
-            position: 0,
         }));
 
         let mut addr = 0;

--- a/src/temper/memory/core.rs
+++ b/src/temper/memory/core.rs
@@ -22,7 +22,7 @@ pub enum MemoryOpType {
 }
 
 thread_local! {
-    pub static MODEL: Mutex<Option<MemoryModel>> = Mutex::new(None);
+    pub static MODEL: Mutex<Option<MemoryModel>> = const { Mutex::new(None) };
 }
 
 pub fn get_model() -> Option<MemoryModel> {

--- a/src/temper/system/core.rs
+++ b/src/temper/system/core.rs
@@ -16,7 +16,7 @@ pub struct SystemInfo {
 }
 
 thread_local! {
-    pub static SYSTEM: Mutex<Option<SystemInfo>> = Mutex::new(None);
+    pub static SYSTEM: Mutex<Option<SystemInfo>> = const { Mutex::new(None) };
 }
 
 pub fn with_system<T, F: FnOnce(&SystemInfo) -> T>(f: F) -> T {


### PR DESCRIPTION
This seems like an accidental copy and paste error when I added the samples - tests 3.10 & 3.11 are duplicates simulating sample 3.10 from the book, and test 3.12 simulates sample 3.11 from the book.