### PR TITLE
Make Mutex initialisation const to satisfy Clippy

### DIFF
--- a/src/temper/memory/core.rs
+++ b/src/temper/memory/core.rs
@@ -22,7 +22,7 @@ pub enum MemoryOpType {
 }
 
 thread_local! {
-    pub static MODEL: Mutex<Option<MemoryModel>> = Mutex::new(None);
+    pub static MODEL: Mutex<Option<MemoryModel>> = const { Mutex::new(None) };
 }
 
 pub fn get_model() -> Option<MemoryModel> {

--- a/src/temper/system/core.rs
+++ b/src/temper/system/core.rs
@@ -16,7 +16,7 @@ pub struct SystemInfo {
 }
 
 thread_local! {
-    pub static SYSTEM: Mutex<Option<SystemInfo>> = Mutex::new(None);
+    pub static SYSTEM: Mutex<Option<SystemInfo>> = const { Mutex::new(None) };
 }
 
 pub fn with_system<T, F: FnOnce(&SystemInfo) -> T>(f: F) -> T {


### PR DESCRIPTION
The latest versions of Rust allow const Mutex construction, and it is enforced by Clippy in static contexts.