### PR TITLE
Add atomic swap to memlog backends

### DIFF
--- a/memlog/src/backend.rs
+++ b/memlog/src/backend.rs
@@ -20,6 +20,10 @@ pub trait MemoryBackend: Send {
         level: Ordering,
     ) -> usize;
 
+    fn swap(&mut self, thread: usize, addr: usize, new: usize, level: Ordering) -> usize {
+        self.fetch_op(thread, addr, &|_| new, level)
+    }
+
     fn compare_exchange(
         &mut self,
         thread: usize,
@@ -98,6 +102,32 @@ pub type MemorySystem = log::MemorySystem;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn swap_replaces_value_for_all_rmw_orderings() {
+        let orderings = [
+            Ordering::Relaxed,
+            Ordering::Acquire,
+            Ordering::Release,
+            Ordering::AcqRel,
+            Ordering::SeqCst,
+        ];
+
+        for mut memory in create_all() {
+            let address = memory.malloc(1);
+            let thread = memory.add_thread();
+            memory.store(thread, address, 1, Ordering::SeqCst);
+
+            for (index, ordering) in orderings.into_iter().enumerate() {
+                assert_eq!(
+                    memory.swap(thread, address, index + 2, ordering),
+                    index + 1,
+                    "{} backend with {ordering:?}",
+                    memory.name()
+                );
+            }
+        }
+    }
 
     fn load_samples(mut memory: impl MemoryBackend) -> Vec<usize> {
         let address = memory.malloc(1);

--- a/memlog/src/graph.rs
+++ b/memlog/src/graph.rs
@@ -159,6 +159,10 @@ impl MemorySystem {
         current
     }
 
+    pub fn swap(&mut self, thread: usize, addr: usize, new: usize, level: Ordering) -> usize {
+        self.fetch_op(thread, addr, |_| new, level)
+    }
+
     pub fn compare_exchange(
         &mut self,
         thread: usize,

--- a/memlog/src/log.rs
+++ b/memlog/src/log.rs
@@ -176,6 +176,10 @@ impl MemorySystem {
             .unwrap()
     }
 
+    pub fn swap(&mut self, thread: usize, addr: usize, new: usize, level: Ordering) -> usize {
+        self.fetch_op(thread, addr, |_| new, level)
+    }
+
     pub fn compare_exchange(
         &mut self,
         thread: usize,


### PR DESCRIPTION
## Summary
- add swap as a backend primitive implemented through fetch_op
- expose swap directly on the log and graph memory systems
- test every valid RMW ordering against both backends

## Verification
- cargo fmt --all --check
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings