### PR TITLE
Fix repeated memlog allocations

### DIFF
--- a/memlog/src/backend.rs
+++ b/memlog/src/backend.rs
@@ -104,6 +104,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn allocations_have_disjoint_addresses() {
+        for mut memory in create_all() {
+            let first = memory.malloc(1);
+            let second = memory.malloc(1);
+            let thread = memory.add_thread();
+
+            memory.store(thread, first, 1, Ordering::SeqCst);
+            assert_eq!(memory.load(thread, first, Ordering::SeqCst), 1);
+            assert_eq!(memory.load(thread, second, Ordering::SeqCst), 0);
+        }
+    }
+
+    #[test]
     fn swap_replaces_value_for_all_rmw_orderings() {
         let orderings = [
             Ordering::Relaxed,

--- a/memlog/src/log.rs
+++ b/memlog/src/log.rs
@@ -385,7 +385,7 @@ impl MemorySystem {
                 global_sequence: 0,
                 level: Ordering::Relaxed,
                 release_chain: false,
-                address: i,
+                address: base + i,
                 value: 0,
                 source_sequence: Default::default(),
                 source_fence_sequence: Default::default(),


### PR DESCRIPTION
## Summary
- record initial log-backend operations at their allocation-relative addresses
- add a backend-wide regression proving repeated allocations remain disjoint

## Testing
- cargo test --workspace
- cargo test --workspace --all-features
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings